### PR TITLE
Remove formatting from Makefile to fix gofmt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,7 @@ binary: clean test
 	cp ./misc/guest-configuration-shim ./$(BINDIR)
 
 test: clean
-	go fmt ./main/*
-	test -z "$$(gofmt -s -l -w -e $$(find . -type f -name '*.go' -not -path './vendor/*') | tee /dev/stderr)"
+	gofmt -s -l -w -e $$(find . -type f -name '*.go' -not -path './vendor/*') | tee /dev/stderr
 	test -z "$$(golint . | tee /dev/stderr)"
 	test -z "$$(go vet -v $$(go list ./... | grep -v '/vendor/') | tee /dev/stderr)"
 	go list ./... | grep -v '/vendor/' | xargs go test -cover


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Removing go fmt from Makefile to avoid changing code once uploaded.
Printing out output of gofmt check.

<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.
- [ ] If needed, Version of the Extension was bumped in the misc/manifest.xml file.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/Guest-Configuration-Extension/blob/master/.github/CONTRIBUTING.md).