### PR TITLE
move gofmt, go lint, go vet out of makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,7 @@ before_script:
   - docker info
   - azure telemetry --disable && azure -v
 script:
+  - test -z gofmt -s -l -w -e $$(find . -type f -name '*.go' -not -path './vendor/*') | tee /dev/stderr
+  - test -z "$$(golint . | tee /dev/stderr)"
+  - test -z "$$(go vet -v $$(go list ./... | grep -v '/vendor/') | tee /dev/stderr)"
   - make binary

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
   - docker info
   - azure telemetry --disable && azure -v
 script:
-  - test -z gofmt -s -l -w -e $$(find . -type f -name '*.go' -not -path './vendor/*') | tee /dev/stderr
-  - test -z "$$(golint . | tee /dev/stderr)"
-  - test -z "$$(go vet -v $$(go list ./... | grep -v '/vendor/') | tee /dev/stderr)"
+  - test -z "$(gofmt -s -l -w -e $(find . -type f -name '*.go' -not -path './vendor/*') | tee /dev/stderr)"
+  - test -z "$(golint . | tee /dev/stderr)"
+  - test -z "$(go vet -v $(go list ./... | grep -v '/vendor/') | tee /dev/stderr)"
   - make binary

--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,6 @@ binary: clean test
 	cp ./misc/guest-configuration-shim ./$(BINDIR)
 
 test: clean
-	gofmt -s -l -w -e $$(find . -type f -name '*.go' -not -path './vendor/*') | tee /dev/stderr
-	test -z "$$(golint . | tee /dev/stderr)"
-	test -z "$$(go vet -v $$(go list ./... | grep -v '/vendor/') | tee /dev/stderr)"
 	go list ./... | grep -v '/vendor/' | xargs go test -cover
 
 clean:


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Removing golint, gofmt, and go vet from makefile.
Moving to travis.yml only.

<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and Travis.CI is passing.
- [ ] If needed, Version of the Extension was bumped in the misc/manifest.xml file.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/Guest-Configuration-Extension/blob/master/.github/CONTRIBUTING.md).