### PR TITLE
remove redirect of logging

### DIFF
--- a/misc/guest-configuration-shim
+++ b/misc/guest-configuration-shim
@@ -2,8 +2,6 @@
 
 set -euo pipefail
 readonly SCRIPT_DIR=$(dirname "$0")
-readonly LOG_DIR="/var/log/azure/guest-configuration"
-readonly LOG_FILE=handler.log
 readonly HANDLER_BIN="guest-configuration-extension"
 
 # status_file returns the .status file path we are supposed to write
@@ -54,10 +52,6 @@ if [ "$#" -ne 1 ]; then
     echo "Usage: $0 <command>"
     exit 1
 fi
-
-# Redirect logs of the handler process
-mkdir -p "$LOG_DIR"
-exec &> >(tee -ia "$LOG_DIR/$LOG_FILE")
 
 # Start handling the process in the background
 bin="$(readlink -f "$SCRIPT_DIR/$HANDLER_BIN")"


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

The logs were being redirected to a new folder called guest-configuration. The redirect was removed, so the logs will remain in the existing log folder. 

<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [x] New Unit tests were added for the changes made and Travis.CI is passing.
- [x] If needed, Version of the Extension was bumped in the misc/manifest.xml file.

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/Guest-Configuration-Extension/blob/master/.github/CONTRIBUTING.md).