### PR TITLE
Add update bug workaround

### DIFF
--- a/main/constants.go
+++ b/main/constants.go
@@ -57,4 +57,7 @@ const (
 
 	// AgentVersionRegex helps return the version of the extension
 	AgentVersionRegex = "^([./a-zA-Z0-9]*)_([0-9.]*)?[.](.*)$"
+
+	// If we return failure from update, the Guest Agent goes into an infinite loop. Fixed in the next GA deployment.
+	UpdateFailFileName = "./update_failed"
 )

--- a/main/main.go
+++ b/main/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -56,6 +57,21 @@ func main() {
 	}
 	lg.event("seqNum: " + strconv.Itoa(seqNum))
 
+	if cmd.name == "install" {
+		exists := true
+		if _, err := os.Stat(UpdateFailFileName); os.IsNotExist(err) {
+			exists = false
+		}
+		if exists {
+			updateError := errors.New("detected an update failure from install")
+			lg.eventError("update failed", updateError)
+			telemetry(TelemetryScenario, "detected an update failure from install", false, 0)
+			reportStatus(lg, hEnv, seqNum, status.StatusError, cmd, updateError.Error())
+			os.Remove(UpdateFailFileName)
+			os.Exit(updateCode)
+		}
+	}
+
 	// check sub-command preconditions, if any, before executing
 	lg.event("start operation")
 	if cmd.pre != nil {
@@ -73,9 +89,17 @@ func main() {
 
 	if cmdErr := cmd.f(lg, hEnv, seqNum); cmdErr != nil {
 		lg.eventError("command failed", cmdErr)
-		reportStatus(lg, hEnv, seqNum, status.StatusError, cmd, cmdErr.Error())
 		telemetry(TelemetryScenario, cmd.name+" failed: "+cmdErr.Error(), false, 0)
-		os.Exit(cmd.failExitCode)
+		if cmd.name == "update" {
+			// never fail on update to avoid a never-ending update loop bug in the Guest Agent
+			// instead create a file to signal to the next install that we failed
+			os.OpenFile(UpdateFailFileName, os.O_RDONLY|os.O_CREATE, 0600)
+			reportStatus(lg, hEnv, seqNum, status.StatusSuccess, cmd, "")
+			os.Exit(successCode)
+		} else {
+			reportStatus(lg, hEnv, seqNum, status.StatusError, cmd, cmdErr.Error())
+			os.Exit(cmd.failExitCode)
+		}
 	}
 	reportStatus(lg, hEnv, seqNum, status.StatusSuccess, cmd, "")
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

There is a bug in the Guest Agent in which if you return failure from update, the agent will get stuck in an infinite update loop. So instead of failing from update, I am writing a file that update failed and then returning success to the GA. Since GA runs install directly after update, install is then checking if the update failure file exists and failing if it does.

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- ~[ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.~
- ~[ ] If applicable, the PR references the bug/issue that it fixes in the description.~
- ~[ ] New Unit tests were added for the changes made and Travis.CI is passing.~
- ~[ ] If needed, Version of the Extension was bumped in the misc/manifest.xml file.~

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/Guest-Configuration-Extension/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/guest-configuration-extension/62)
<!-- Reviewable:end -->
