### PR TITLE
Remove update and always return success from disable

### DIFF
--- a/main/cmds.go
+++ b/main/cmds.go
@@ -127,55 +127,10 @@ func enable(lg ExtensionLogger, hEnv vmextension.HandlerEnvironment, seqNum int)
 }
 
 func update(lg ExtensionLogger, hEnv vmextension.HandlerEnvironment, seqNum int) error {
-	// parse the extension handler settings
-	cfg, err := parseAndValidateSettings(hEnv.HandlerEnvironment.ConfigFolder)
-	if err != nil {
-		return errors.Wrap(err, "failed to get configuration")
-	}
-
-	// get old agent path
-	oldAgent, err := getOldAgentPath(lg)
-	if err != nil {
-		lg.eventError("failed to get old agent path", err)
-		return errors.Wrap(err, "failed to get old agent path")
-	}
-	lg.event("Got the oldAgent path: " + oldAgent)
-
-	// parse and log the new agent version
-	//_, err = parseAndLogAgentVersion(lg, AgentZipDir)
-	//if err != nil {
-	//	lg.customLog(logEvent, "failed to parse version string", logError, err, logAgentName, AgentZipDir)
-	//	return errors.Wrap(err, "failed to parse version string")
-	//}
-
-	// unzipAgent new agent
-	unzipDir, agentDirectory := getAgentPaths()
-	_, err = unzipAgent(lg, AgentZipDir, AgentName, unzipDir)
-	if err != nil {
-		lg.eventError("failed to unzipAgent agent dir", err)
-		return errors.Wrap(err, "failed to unzipAgent agent")
-	}
-	// set permissions for the .sh files
-	err = setPermissions()
-	if err != nil {
-		lg.eventError("failed to update the permissions for the scripts", err)
-		telemetry(TelemetryScenario, err.Error(), false, 0)
-		return nil
-	}
-
-	// run new update.sh to update the agent
-	lg.event("updating agent")
-	_, runErr := runCmd(lg, "bash ./update.sh "+oldAgent, agentDirectory, cfg)
-	if runErr != nil {
-		lg.eventError("agent update failed", runErr)
-		telemetry(TelemetryScenario, "agent update failed: "+runErr.Error(), false, 0)
-	} else {
-		lg.event("agent update succeeded")
-		telemetry(TelemetryScenario, "agent update succeeded", true, 0)
-	}
-
+	// update does not need to do any migration at the moment
 	// collect the logs if available and send telemetry updates
-	getStdPipesAndTelemetry(lg, unzipDir, runErr)
+	unzipDir, _ := getAgentPaths()
+	getStdPipesAndTelemetry(lg, unzipDir, nil)
 
 	return nil
 }


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
After discussion with the Guest Agent team, we do not need update to do anything, so I have removed what it was previously doing. I also removed the workaround to fail update during install since we no longer need to do anything during update and can always return success.

Also, the infinite retry bug seems to affect only disable for us, so we will always return success from disable. This should be ok since disable only stops the service. The customer should only want to do that if they were uninstalling the agent. Uninstall will also separately attempt to stop the service, and should that fail, then uninstall can return failure.

---

### PR information
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- ~[ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.~
- ~[ ] If applicable, the PR references the bug/issue that it fixes in the description.~
- ~[ ] New Unit tests were added for the changes made and Travis.CI is passing.~
- ~[ ] If needed, Version of the Extension was bumped in the misc/manifest.xml file.~

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/Guest-Configuration-Extension/blob/master/.github/CONTRIBUTING.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/azure/guest-configuration-extension/65)
<!-- Reviewable:end -->
