### PR TITLE
Add manifest to delete unused GCLinux extension from prod

### DIFF
--- a/misc/manifest_to_deletexml
+++ b/misc/manifest_to_deletexml
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
+  <ProviderNameSpace>Microsoft.GuestConfiguration</ProviderNameSpace>
+  <Type>ConfigurationForLinux</Type>
+  <Version>1.26.5</Version>
+  <Label>Microsoft Azure Guest Configuration Extension for Linux Virtual Machines</Label>
+  <HostingResources>VmRole</HostingResources>
+  <MediaLink></MediaLink>
+  <Description>Microsoft Azure Guest Configuration Extension for Linux Virtual Machines</Description>
+  <IsInternalExtension>true</IsInternalExtension>
+  <Eula>https://github.com/Azure/Guest-Configuration-Extension/blob/master/LICENSE</Eula>
+  <PrivacyUri>http://www.microsoft.com/privacystatement/en-us/OnlineServices/Default.aspx</PrivacyUri>
+  <HomepageUri>https://github.com/Azure/Guest-Configuration-Extension</HomepageUri>
+  <IsJsonExtension>true</IsJsonExtension>
+  <SupportedOS>Linux</SupportedOS>
+  <CompanyName>Microsoft</CompanyName>
+  <!--%REGIONS%-->
+</ExtensionImage>


### PR DESCRIPTION
created a manifest file that will contain the extension version to be deleted. this manifest is copy of existing manifest. only the ext version no is diff