### PR TITLE
Publish Guest Configuration extension version 1.26.24

### DIFF
--- a/misc/manifest.xml
+++ b/misc/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.GuestConfiguration</ProviderNameSpace>
   <Type>ConfigurationForLinux</Type>
-  <Version>1.26.18</Version>
+  <Version>1.26.24</Version>
   <Label>Microsoft Azure Guest Configuration Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>


### PR DESCRIPTION
Publish Guest Configuration extension version 1.26.24
Release Notes:-

1.	Restart GCAgent service after every 48 hours.
2.	Make reason code and phrase properties case insensitive.
3.	Increase max no of logs files from 5 to 10.
4.	Add retry around service restart.
5.	Fix crash happening at the of service stop on linux machine.
6.	Config mode and solution type should not be overwritten by metaconfig file.
7.	Send error report if policy execution times out.
8.	Check if package is capable to run Set operation.
