### PR TITLE
Guest Configuration Linux extension should report unsupported distros

### DIFF
--- a/main/cmds.go
+++ b/main/cmds.go
@@ -107,9 +107,9 @@ func enable(lg ExtensionLogger, hEnv vmextension.HandlerEnvironment, seqNum int)
 	err_code, runErr = runCmd(lg, "bash ./install.sh", agentDirectory, cfg)
 	if runErr != nil {
 		lg.eventError("agent installation failed", runErr)
-		telemetry(TelemetryScenario, "agent installation failed: "+runErr.Error()+", Error code: "+err_code, false, 0)
+		telemetry(TelemetryScenario, "agent installation failed: "+runErr.Error(), false, 0)
 		if err_code == 51 {
-			telemetry(TelemetryScenario, "Exiting with error code : "+err_code, false, 0)
+			telemetry(TelemetryScenario, "Exiting with error code : 51", false, 0)
 			os.Exit(err_code)
 		}
 	} else {

--- a/main/cmds.go
+++ b/main/cmds.go
@@ -39,11 +39,11 @@ var (
 	}
 )
 
-func install(lg ExtensionLogger, hEnv vmextension.HandlerEnvironment, seqNum int) error {
+func install(lg ExtensionLogger, hEnv vmextension.HandlerEnvironment, seqNum int) (code int, err error) {
 	msg := "Extension install succeeded"
 	lg.event(msg)
 	telemetry(TelemetryScenario, msg, true, 0)
-	return nil
+	return 0, nil
 }
 
 func enablePre(lg ExtensionLogger, seqNum int) error {
@@ -58,11 +58,11 @@ func enablePre(lg ExtensionLogger, seqNum int) error {
 	return nil
 }
 
-func enable(lg ExtensionLogger, hEnv vmextension.HandlerEnvironment, seqNum int) error {
+func enable(lg ExtensionLogger, hEnv vmextension.HandlerEnvironment, seqNum int) (code int, err error) {
 	// parse the extension handler settings (file not available prior to 'enable')
 	cfg, err := parseAndValidateSettings(hEnv.HandlerEnvironment.ConfigFolder)
 	if err != nil {
-		return errors.Wrap(err, "failed to get configuration")
+		return -1, errors.Wrap(err, "failed to get configuration")
 	}
 
 	// parse and log the agent version
@@ -78,44 +78,39 @@ func enable(lg ExtensionLogger, hEnv vmextension.HandlerEnvironment, seqNum int)
 	if _, err := os.Stat(agentDirectory); err == nil {
 		// directory exists, run enable.sh for agent health check
 		lg.event("agent health check")
-		_, runErr := runCmd(lg, "bash ./enable.sh", agentDirectory, cfg)
+		code, runErr := runCmd(lg, "bash ./enable.sh", agentDirectory, cfg)
 		if runErr != nil {
 			lg.eventError("agent health check failed", runErr)
-			return runErr
+			return code, runErr
 		}
 		lg.event("agent health check succeeded")
-		return nil
+		return 0, nil
 	}
 
 	// directory does not exist, unzipAgent agent
 	_, err = unzipAgent(lg, AgentZipDir, AgentName, unzipDir)
 	if err != nil {
 		lg.eventError("failed to unzipAgent agent dir", err)
-		return errors.Wrap(err, "failed to unzipAgent agent")
+		return -1, errors.Wrap(err, "failed to unzipAgent agent")
 	}
 	// set permissions for the .sh files
 	err = setPermissions()
 	if err != nil {
 		lg.eventError("failed to update the permissions for the scripts", err)
 		telemetry(TelemetryScenario, err.Error(), false, 0)
-		return errors.Wrap(err, "failed to update the permissions for the scripts")
+		return -1, errors.Wrap(err, "failed to update the permissions for the scripts")
 	}
 
 	// run install.sh and enable.sh
 	lg.event("installing agent")
-	var err_code int
-	err_code, runErr = runCmd(lg, "bash ./install.sh", agentDirectory, cfg)
+	code, runErr = runCmd(lg, "bash ./install.sh", agentDirectory, cfg)
 	if runErr != nil {
 		lg.eventError("agent installation failed", runErr)
 		telemetry(TelemetryScenario, "agent installation failed: "+runErr.Error(), false, 0)
-		if err_code == 51 {
-			telemetry(TelemetryScenario, "Exiting with error code : 51", false, 0)
-			os.Exit(err_code)
-		}
 	} else {
 		lg.customLog(logEvent, "agent installation succeeded", logEvent, "enabling agent")
 		telemetry(TelemetryScenario, "agent installation succeeded", true, 0)
-		_, runErr = runCmd(lg, "bash ./enable.sh", agentDirectory, cfg)
+		code, runErr = runCmd(lg, "bash ./enable.sh", agentDirectory, cfg)
 		if runErr != nil {
 			lg.eventError("enable agent failed", runErr)
 			telemetry(TelemetryScenario, "agent enable failed: "+runErr.Error(), false, 0)
@@ -128,14 +123,14 @@ func enable(lg ExtensionLogger, hEnv vmextension.HandlerEnvironment, seqNum int)
 	// collect the logs if available and send telemetry updates
 	getStdPipesAndTelemetry(lg, unzipDir, runErr)
 
-	return runErr
+	return code, runErr
 }
 
-func update(lg ExtensionLogger, hEnv vmextension.HandlerEnvironment, seqNum int) error {
+func update(lg ExtensionLogger, hEnv vmextension.HandlerEnvironment, seqNum int) (code int, err error) {
 	// parse the extension handler settings
 	cfg, err := parseAndValidateSettings(hEnv.HandlerEnvironment.ConfigFolder)
 	if err != nil {
-		return errors.Wrap(err, "failed to get configuration")
+		return -1, errors.Wrap(err, "failed to get configuration")
 	}
 
 	// run update.sh to disable the agent
@@ -152,14 +147,14 @@ func update(lg ExtensionLogger, hEnv vmextension.HandlerEnvironment, seqNum int)
 
 	// collect the logs if available and send telemetry updates
 	getStdPipesAndTelemetry(lg, unzipDir, runErr)
-	return nil
+	return 0, nil
 }
 
-func disable(lg ExtensionLogger, hEnv vmextension.HandlerEnvironment, seqNum int) error {
+func disable(lg ExtensionLogger, hEnv vmextension.HandlerEnvironment, seqNum int) (code int, err error) {
 	// parse the extension handler settings
 	cfg, err := parseAndValidateSettings(hEnv.HandlerEnvironment.ConfigFolder)
 	if err != nil {
-		return errors.Wrap(err, "failed to get configuration")
+		return -1, errors.Wrap(err, "failed to get configuration")
 	}
 
 	// run disable.sh to disable the agent
@@ -177,14 +172,14 @@ func disable(lg ExtensionLogger, hEnv vmextension.HandlerEnvironment, seqNum int
 	// collect the logs if available and send telemetry updates
 	getStdPipesAndTelemetry(lg, unzipDir, runErr)
 
-	return nil
+	return 0, nil
 }
 
-func uninstall(lg ExtensionLogger, hEnv vmextension.HandlerEnvironment, seqNum int) error {
+func uninstall(lg ExtensionLogger, hEnv vmextension.HandlerEnvironment, seqNum int) (code int, err error) {
 	// parse the extension handler settings
 	cfg, err := parseAndValidateSettings(hEnv.HandlerEnvironment.ConfigFolder)
 	if err != nil {
-		return errors.Wrap(err, "failed to get configuration")
+		return -1, errors.Wrap(err, "failed to get configuration")
 	}
 
 	// run uninstall.sh to uninstall the agent
@@ -202,5 +197,5 @@ func uninstall(lg ExtensionLogger, hEnv vmextension.HandlerEnvironment, seqNum i
 	// collect the logs if available and send telemetry updates
 	getStdPipesAndTelemetry(lg, unzipDir, runErr)
 
-	return nil
+	return 0, nil
 }

--- a/main/cmds.go
+++ b/main/cmds.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-type cmdfunc func(lg ExtensionLogger, hEnv vmextension.HandlerEnvironment, seqNum int) error
+type cmdfunc func(lg ExtensionLogger, hEnv vmextension.HandlerEnvironment, seqNum int) (code int, err error)
 type prefunc func(lg ExtensionLogger, seqNum int) error
 
 // Add more fields as necessary

--- a/main/cmds.go
+++ b/main/cmds.go
@@ -62,7 +62,7 @@ func enable(lg ExtensionLogger, hEnv vmextension.HandlerEnvironment, seqNum int)
 	// parse the extension handler settings (file not available prior to 'enable')
 	cfg, err := parseAndValidateSettings(hEnv.HandlerEnvironment.ConfigFolder)
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to get configuration")
+		return errors.Wrap(err, "failed to get configuration")
 	}
 
 	// parse and log the agent version
@@ -75,31 +75,30 @@ func enable(lg ExtensionLogger, hEnv vmextension.HandlerEnvironment, seqNum int)
 	// check to see if agent directory exists
 	unzipDir, agentDirectory := getAgentPaths()
 	var runErr error
-	var code int
-	if code, err := os.Stat(agentDirectory); err == nil {
+	if _, err := os.Stat(agentDirectory); err == nil {
 		// directory exists, run enable.sh for agent health check
 		lg.event("agent health check")
-		code, runErr := runCmd(lg, "bash ./enable.sh", agentDirectory, cfg)
+		_, runErr := runCmd(lg, "bash ./enable.sh", agentDirectory, cfg)
 		if runErr != nil {
 			lg.eventError("agent health check failed", runErr)
-			return code, runErr
+			return runErr
 		}
 		lg.event("agent health check succeeded")
-		return 0, nil
+		return nil
 	}
 
 	// directory does not exist, unzipAgent agent
-	code, err = unzipAgent(lg, AgentZipDir, AgentName, unzipDir)
+	_, err = unzipAgent(lg, AgentZipDir, AgentName, unzipDir)
 	if err != nil {
 		lg.eventError("failed to unzipAgent agent dir", err)
-		return code, errors.Wrap(err, "failed to unzipAgent agent")
+		return errors.Wrap(err, "failed to unzipAgent agent")
 	}
 	// set permissions for the .sh files
 	err = setPermissions()
 	if err != nil {
 		lg.eventError("failed to update the permissions for the scripts", err)
 		telemetry(TelemetryScenario, err.Error(), false, 0)
-		return 0, errors.Wrap(err, "failed to update the permissions for the scripts")
+		return errors.Wrap(err, "failed to update the permissions for the scripts")
 	}
 
 	// run install.sh and enable.sh
@@ -107,11 +106,15 @@ func enable(lg ExtensionLogger, hEnv vmextension.HandlerEnvironment, seqNum int)
 	code, runErr = runCmd(lg, "bash ./install.sh", agentDirectory, cfg)
 	if runErr != nil {
 		lg.eventError("agent installation failed", runErr)
-		telemetry(TelemetryScenario, "agent installation failed: "+runErr.Error(), false, 0)
+		telemetry(TelemetryScenario, "agent installation failed: "+runErr.Error()+", Error code: "+code, false, 0)
+		if code == 51 {
+			telemetry(TelemetryScenario, "Exiting with error code : "+code, false, 0)
+			os.Exit(code)
+		}
 	} else {
 		lg.customLog(logEvent, "agent installation succeeded", logEvent, "enabling agent")
 		telemetry(TelemetryScenario, "agent installation succeeded", true, 0)
-		code, runErr = runCmd(lg, "bash ./enable.sh", agentDirectory, cfg)
+		_, runErr = runCmd(lg, "bash ./enable.sh", agentDirectory, cfg)
 		if runErr != nil {
 			lg.eventError("enable agent failed", runErr)
 			telemetry(TelemetryScenario, "agent enable failed: "+runErr.Error(), false, 0)
@@ -124,7 +127,7 @@ func enable(lg ExtensionLogger, hEnv vmextension.HandlerEnvironment, seqNum int)
 	// collect the logs if available and send telemetry updates
 	getStdPipesAndTelemetry(lg, unzipDir, runErr)
 
-	return code, runErr
+	return runErr
 }
 
 func update(lg ExtensionLogger, hEnv vmextension.HandlerEnvironment, seqNum int) error {
@@ -148,7 +151,7 @@ func update(lg ExtensionLogger, hEnv vmextension.HandlerEnvironment, seqNum int)
 
 	// collect the logs if available and send telemetry updates
 	getStdPipesAndTelemetry(lg, unzipDir, runErr)
-	return 0, nil
+	return nil
 }
 
 func disable(lg ExtensionLogger, hEnv vmextension.HandlerEnvironment, seqNum int) error {
@@ -173,7 +176,7 @@ func disable(lg ExtensionLogger, hEnv vmextension.HandlerEnvironment, seqNum int
 	// collect the logs if available and send telemetry updates
 	getStdPipesAndTelemetry(lg, unzipDir, runErr)
 
-	return 0, nil
+	return nil
 }
 
 func uninstall(lg ExtensionLogger, hEnv vmextension.HandlerEnvironment, seqNum int) error {
@@ -198,5 +201,5 @@ func uninstall(lg ExtensionLogger, hEnv vmextension.HandlerEnvironment, seqNum i
 	// collect the logs if available and send telemetry updates
 	getStdPipesAndTelemetry(lg, unzipDir, runErr)
 
-	return 0, nil
+	return nil
 }

--- a/main/cmds.go
+++ b/main/cmds.go
@@ -103,13 +103,14 @@ func enable(lg ExtensionLogger, hEnv vmextension.HandlerEnvironment, seqNum int)
 
 	// run install.sh and enable.sh
 	lg.event("installing agent")
-	code, runErr = runCmd(lg, "bash ./install.sh", agentDirectory, cfg)
+	var err_code int
+	err_code, runErr = runCmd(lg, "bash ./install.sh", agentDirectory, cfg)
 	if runErr != nil {
 		lg.eventError("agent installation failed", runErr)
-		telemetry(TelemetryScenario, "agent installation failed: "+runErr.Error()+", Error code: "+code, false, 0)
-		if code == 51 {
-			telemetry(TelemetryScenario, "Exiting with error code : "+code, false, 0)
-			os.Exit(code)
+		telemetry(TelemetryScenario, "agent installation failed: "+runErr.Error()+", Error code: "+err_code, false, 0)
+		if err_code == 51 {
+			telemetry(TelemetryScenario, "Exiting with error code : "+err_code, false, 0)
+			os.Exit(err_code)
 		}
 	} else {
 		lg.customLog(logEvent, "agent installation succeeded", logEvent, "enabling agent")

--- a/main/main.go
+++ b/main/main.go
@@ -71,10 +71,6 @@ func main() {
 	lg.event("Reporting transitioning status...")
 	reportStatus(lg, hEnv, seqNum, status.StatusTransitioning, cmd, "Transitioning")
 
-	telemetry(TelemetryScenario, "testing .... Exiting with error code : 51", false, 0)
-	reportStatus(lg, hEnv, seqNum, status.UnsupportedOS, cmd, "UnsupportedOSMsg")
-	os.Exit(51)
-
 	if err_code, cmdErr := cmd.f(lg, hEnv, seqNum); cmdErr != nil {
 		message := "Operation '" + cmd.name + "' failed."
 		lg.eventError(message, cmdErr)
@@ -83,7 +79,7 @@ func main() {
 		if cmd.name != "disable" {
 			if err_code == 51 {
 				telemetry(TelemetryScenario, "Exiting with error code : 51", false, 0)
-				reportStatus(lg, hEnv, seqNum, status.UnsupportedOS, cmd, "UnsupportedOS")
+				reportStatus(lg, hEnv, seqNum, status.StatusError, cmd, "UnsupportedOS")
 				os.Exit(err_code)
 			} else {
 				reportStatus(lg, hEnv, seqNum, status.StatusError, cmd, cmdErr.Error())

--- a/main/main.go
+++ b/main/main.go
@@ -71,6 +71,11 @@ func main() {
 	lg.event("Reporting transitioning status...")
 	reportStatus(lg, hEnv, seqNum, status.StatusTransitioning, cmd, "Transitioning")
 
+	telemetry(TelemetryScenario, "testing .... Exiting with error code : 51", false, 0)
+	lg.eventError(message, "testing .... Exiting with error code : 51")
+	reportStatus(lg, hEnv, seqNum, status.UnsupportedOS, cmd, "UnsupportedOSMsg")
+	os.Exit(51)
+
 	if err_code, cmdErr := cmd.f(lg, hEnv, seqNum); cmdErr != nil {
 		message := "Operation '" + cmd.name + "' failed."
 		lg.eventError(message, cmdErr)

--- a/main/main.go
+++ b/main/main.go
@@ -72,7 +72,8 @@ func main() {
 	reportStatus(lg, hEnv, seqNum, status.StatusTransitioning, cmd, "Transitioning")
 
 	if err_code, cmdErr := cmd.f(lg, hEnv, seqNum); cmdErr != nil {
-		message := "Operation '" + cmd.name + "' failed."
+		message := "Operation '" + cmd.name + "' failed. Error code: " + strconv.Itoa(err_code)
+
 		lg.eventError(message, cmdErr)
 		telemetry(TelemetryScenario, message+" Error: '"+cmdErr.Error()+"'.", false, 0)
 		// Never fail on disable due to a current bug in the Guest Agent

--- a/main/main.go
+++ b/main/main.go
@@ -71,18 +71,14 @@ func main() {
 	lg.event("Reporting transitioning status...")
 	reportStatus(lg, hEnv, seqNum, status.StatusTransitioning, cmd, "Transitioning")
 
-	if code, cmdErr := cmd.f(lg, hEnv, seqNum); cmdErr != nil {
+	if cmdErr := cmd.f(lg, hEnv, seqNum); cmdErr != nil {
 		message := "Operation '" + cmd.name + "' failed."
 		lg.eventError(message, cmdErr)
-		telemetry(TelemetryScenario, message+" Error: '"+cmdErr.Error()+"', ErrorCode: '"+code+"'.", false, 0)
+		telemetry(TelemetryScenario, message+" Error: '"+cmdErr.Error()+"'.", false, 0)
 		// Never fail on disable due to a current bug in the Guest Agent
 		if cmd.name != "disable" {
 			reportStatus(lg, hEnv, seqNum, status.StatusError, cmd, cmdErr.Error())
-			if(code != 51) {
-				os.Exit(cmd.failExitCode)
-			} else {
-				os.Exit(51)
-			}
+			os.Exit(cmd.failExitCode)
 		}
 	} else {
 		message := "Operation '" + cmd.name + "' succeeded."

--- a/main/main.go
+++ b/main/main.go
@@ -71,14 +71,21 @@ func main() {
 	lg.event("Reporting transitioning status...")
 	reportStatus(lg, hEnv, seqNum, status.StatusTransitioning, cmd, "Transitioning")
 
-	if cmdErr := cmd.f(lg, hEnv, seqNum); cmdErr != nil {
+	var err_code int
+	if err_code, cmdErr := cmd.f(lg, hEnv, seqNum); cmdErr != nil {
 		message := "Operation '" + cmd.name + "' failed."
 		lg.eventError(message, cmdErr)
 		telemetry(TelemetryScenario, message+" Error: '"+cmdErr.Error()+"'.", false, 0)
 		// Never fail on disable due to a current bug in the Guest Agent
 		if cmd.name != "disable" {
-			reportStatus(lg, hEnv, seqNum, status.StatusError, cmd, cmdErr.Error())
-			os.Exit(cmd.failExitCode)
+			if err_code == 51 {
+				telemetry(TelemetryScenario, "Exiting with error code : 51", false, 0)
+				reportStatus(lg, hEnv, seqNum, status.StatusError, cmd, "UnsupportedOS")
+				os.Exit(err_code)
+			} else {
+				reportStatus(lg, hEnv, seqNum, status.StatusError, cmd, cmdErr.Error())
+				os.Exit(cmd.failExitCode)
+			}
 		}
 	} else {
 		message := "Operation '" + cmd.name + "' succeeded."

--- a/main/main.go
+++ b/main/main.go
@@ -71,14 +71,18 @@ func main() {
 	lg.event("Reporting transitioning status...")
 	reportStatus(lg, hEnv, seqNum, status.StatusTransitioning, cmd, "Transitioning")
 
-	if cmdErr := cmd.f(lg, hEnv, seqNum); cmdErr != nil {
+	if code, cmdErr := cmd.f(lg, hEnv, seqNum); cmdErr != nil {
 		message := "Operation '" + cmd.name + "' failed."
 		lg.eventError(message, cmdErr)
-		telemetry(TelemetryScenario, message+" Error: '"+cmdErr.Error()+"'.", false, 0)
+		telemetry(TelemetryScenario, message+" Error: '"+cmdErr.Error()+"', ErrorCode: '"+code+"'.", false, 0)
 		// Never fail on disable due to a current bug in the Guest Agent
 		if cmd.name != "disable" {
 			reportStatus(lg, hEnv, seqNum, status.StatusError, cmd, cmdErr.Error())
-			os.Exit(cmd.failExitCode)
+			if(code != 51) {
+				os.Exit(cmd.failExitCode)
+			} else {
+				os.Exit(51)
+			}
 		}
 	} else {
 		message := "Operation '" + cmd.name + "' succeeded."

--- a/main/main.go
+++ b/main/main.go
@@ -71,7 +71,6 @@ func main() {
 	lg.event("Reporting transitioning status...")
 	reportStatus(lg, hEnv, seqNum, status.StatusTransitioning, cmd, "Transitioning")
 
-	var err_code int
 	if err_code, cmdErr := cmd.f(lg, hEnv, seqNum); cmdErr != nil {
 		message := "Operation '" + cmd.name + "' failed."
 		lg.eventError(message, cmdErr)

--- a/main/main.go
+++ b/main/main.go
@@ -80,7 +80,7 @@ func main() {
 			if err_code == 51 {
 				telemetry(TelemetryScenario, "Exiting with error code : 51", false, 0)
 				lg.eventError(message, "Exiting with error code : 51")
-				reportStatus(lg, hEnv, seqNum, status.StatusError, cmd, "UnsupportedOS")
+				reportStatus(lg, hEnv, seqNum, status.UnsupportedOS, cmd, "UnsupportedOS")
 				os.Exit(err_code)
 			} else {
 				reportStatus(lg, hEnv, seqNum, status.StatusError, cmd, cmdErr.Error())

--- a/main/main.go
+++ b/main/main.go
@@ -72,7 +72,6 @@ func main() {
 	reportStatus(lg, hEnv, seqNum, status.StatusTransitioning, cmd, "Transitioning")
 
 	telemetry(TelemetryScenario, "testing .... Exiting with error code : 51", false, 0)
-	lg.eventError(message, "testing .... Exiting with error code : 51")
 	reportStatus(lg, hEnv, seqNum, status.UnsupportedOS, cmd, "UnsupportedOSMsg")
 	os.Exit(51)
 
@@ -84,7 +83,6 @@ func main() {
 		if cmd.name != "disable" {
 			if err_code == 51 {
 				telemetry(TelemetryScenario, "Exiting with error code : 51", false, 0)
-				lg.eventError(message, "Exiting with error code : 51")
 				reportStatus(lg, hEnv, seqNum, status.UnsupportedOS, cmd, "UnsupportedOS")
 				os.Exit(err_code)
 			} else {

--- a/main/main.go
+++ b/main/main.go
@@ -72,14 +72,14 @@ func main() {
 	reportStatus(lg, hEnv, seqNum, status.StatusTransitioning, cmd, "Transitioning")
 
 	if err_code, cmdErr := cmd.f(lg, hEnv, seqNum); cmdErr != nil {
-		message := "Operation '" + cmd.name + "' failed. Error code: " + strconv.Itoa(err_code)
-
+		message := "Operation '" + cmd.name + "' failed."
 		lg.eventError(message, cmdErr)
 		telemetry(TelemetryScenario, message+" Error: '"+cmdErr.Error()+"'.", false, 0)
 		// Never fail on disable due to a current bug in the Guest Agent
 		if cmd.name != "disable" {
 			if err_code == 51 {
 				telemetry(TelemetryScenario, "Exiting with error code : 51", false, 0)
+				lg.eventError(message, "Exiting with error code : 51")
 				reportStatus(lg, hEnv, seqNum, status.StatusError, cmd, "UnsupportedOS")
 				os.Exit(err_code)
 			} else {

--- a/misc/manifest.xml
+++ b/misc/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.GuestConfiguration</ProviderNameSpace>
   <Type>ConfigurationForLinux</Type>
-  <Version>1.26.30</Version>
+  <Version>1.26.31</Version>
   <Label>Microsoft Azure Guest Configuration Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>

--- a/vendor/github.com/Azure/azure-docker-extension/pkg/vmextension/status/status.go
+++ b/vendor/github.com/Azure/azure-docker-extension/pkg/vmextension/status/status.go
@@ -23,6 +23,7 @@ const (
 	StatusTransitioning Type = "transitioning"
 	StatusError         Type = "error"
 	StatusSuccess       Type = "success"
+	UnsupportedOS       Type = "unsupportedOS"
 )
 
 type Status struct {

--- a/vendor/github.com/Azure/azure-docker-extension/pkg/vmextension/status/status.go
+++ b/vendor/github.com/Azure/azure-docker-extension/pkg/vmextension/status/status.go
@@ -23,7 +23,6 @@ const (
 	StatusTransitioning Type = "transitioning"
 	StatusError         Type = "error"
 	StatusSuccess       Type = "success"
-	UnsupportedOS       Type = "unsupportedOS"
 )
 
 type Status struct {


### PR DESCRIPTION
Guest Configuration extension reports success even if the target machine is not supported. installation script enable.sh check for the distro and exists with error 51 but extension binaries are ignoring the 51 error code.

Modifying the extension to check for error code 51 so that it can notify unsupported distros. 
rest of the behavior is same as it was before.