### PR TITLE
Publish Extension version 1.26.35

### DIFF
--- a/misc/manifest.xml
+++ b/misc/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.GuestConfiguration</ProviderNameSpace>
   <Type>ConfigurationForLinux</Type>
-  <Version>1.26.34</Version>
+  <Version>1.26.35</Version>
   <Label>Microsoft Azure Guest Configuration Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>


### PR DESCRIPTION
Publish Guest Configuration extension version 1.26.35

Release notes:-
1. Support user assigned identity
2. Linux agent is creating 100s of directory in temp folder
3. Gc_worker is hanging after policy execution on suse machine.